### PR TITLE
Option to disable default og:images

### DIFF
--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -21,12 +21,14 @@
 <meta property="og:type" content="{{ og_type }}">
 <meta property="og:description" content="{{ og_description | escape }}">
 
-{%- if page_image -%}
-  <meta property="og:image" content="http:{{ page_image | img_url: 'master' }}">
-  <meta property="og:image:secure_url" content="https:{{ page_image | img_url: 'master' }}">
-  <meta property="og:image:width" content="{{ page_image.width }}">
-  <meta property="og:image:height" content="{{ page_image.height }}">
-{%- endif -%}
+{%- unless shop.metafields.overrides.og_image -%}
+  {%- if page_image -%}
+    <meta property="og:image" content="http:{{ page_image | img_url: 'master' }}">
+    <meta property="og:image:secure_url" content="https:{{ page_image | img_url: 'master' }}">
+    <meta property="og:image:width" content="{{ page_image.width }}">
+    <meta property="og:image:height" content="{{ page_image.height }}">
+  {%- endif -%}
+{%- endunless -%}
 
 {%- if request.page_type == 'product' -%}
   <meta property="og:price:amount" content="{{ product.price | money_without_currency | strip_html }}">


### PR DESCRIPTION
**Why are these changes introduced?**

Shopify Apps want to use App Blocks to add bespoke `<meta property="og:image">` properties, such as https://mocralivelinks.com.

Shopify Apps can now disable Dawn's default `og:image` by setting the metafield `shop.metafields.overrides.og_image = true`

**What approach did you take?**

An optional metafield on Shop to be set by a Shopify App.

**Other considerations**

There are no other examples of using `shop.metafields` to allow Apps to enable/disable features of this theme. Please let me know what best practices exist for naming the metafield.

**Demo links**

- https://mocra-dev-with-designer.myshopify.com/products/adidas-classic-backpack - the `og:image` and friends are added via an App Block, and the original Dawn `og:image` has been removed
- 
**Checklist**
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
